### PR TITLE
Fix arc movements for Aspire

### DIFF
--- a/assets/snapmaker-aspire-configuration/Snapmaker_cnc_mm.pp
+++ b/assets/snapmaker-aspire-configuration/Snapmaker_cnc_mm.pp
@@ -1,15 +1,15 @@
 +================================================
-+                                                
-+    Vectric machine output configuration file   
-+                                                
++
++    Vectric machine output configuration file
++
 +================================================
-+                                                
-+ History                                        
-+                                                
-+ Who      When       What                         
++
++ History
++
++ Who      When       What
 + ======== ========== ===========================
-+ Tony M   13/09/2010 Written  
-+ Mark     16/07/2015 Added New Segment section.                    
++ Tony M   13/09/2010 Written
++ Mark     16/07/2015 Added New Segment section.
 + ================================================
 
 POST_NAME = "Snapmaker CNC (mm) (*.cnc)"
@@ -19,13 +19,13 @@ FILE_EXTENSION = "cnc"
 UNITS = "MM"
 
 +------------------------------------------------
-+    Line terminating characters                 
++    Line terminating characters
 +------------------------------------------------
 
 LINE_ENDING = "[13][10]"
 
 +------------------------------------------------
-+    Block numbering                             
++    Block numbering
 +------------------------------------------------
 
 LINE_NUMBER_START     = 0
@@ -33,9 +33,9 @@ LINE_NUMBER_INCREMENT = 10
 LINE_NUMBER_MAXIMUM = 9999999
 
 +================================================
-+                                                
-+    Formating for variables                     
-+                                                
++
++    Formating for variables
++
 +================================================
 
 VAR LINE_NUMBER = [N|A| N|1.0]
@@ -44,16 +44,16 @@ VAR FEED_RATE = [F|C| F|1.1]
 VAR X_POSITION = [X|C| X|1.3]
 VAR Y_POSITION = [Y|C| Y|1.3]
 VAR Z_POSITION = [Z|C| Z|1.3]
-VAR ARC_CENTRE_I_ABS_POSITION = [IA|A| I|1.3]
-VAR ARC_CENTRE_J_ABS_POSITION = [JA|A| J|1.3]
+VAR ARC_CENTRE_I_INC_POSITION = [I|A| I|1.3]
+VAR ARC_CENTRE_J_INC_POSITION = [J|A| J|1.3]
 VAR X_HOME_POSITION = [XH|A| X|1.3]
 VAR Y_HOME_POSITION = [YH|A| Y|1.3]
 VAR Z_HOME_POSITION = [ZH|A| Z|1.3]
 
 +================================================
-+                                                
-+    Block definitions for toolpath output       
-+                                                
++
++    Block definitions for toolpath output
++
 +================================================
 
 +---------------------------------------------------
@@ -68,7 +68,7 @@ begin HEADER
 "M3 [S]"
 
 +---------------------------------------------------
-+  Commands output for rapid moves 
++  Commands output for rapid moves
 +---------------------------------------------------
 
 begin RAPID_MOVE
@@ -100,7 +100,7 @@ begin FEED_MOVE
 
 begin FIRST_CW_ARC_MOVE
 
-"G2 [X] [Y] [IA] [JA] [F]"
+"G2 [X] [Y] [I] [J] [F]"
 
 
 +---------------------------------------------------
@@ -109,7 +109,7 @@ begin FIRST_CW_ARC_MOVE
 
 begin CW_ARC_MOVE
 
-"G2 [X] [Y] [IA] [JA]"
+"G2 [X] [Y] [I] [J]"
 
 
 +---------------------------------------------------
@@ -118,7 +118,7 @@ begin CW_ARC_MOVE
 
 begin FIRST_CCW_ARC_MOVE
 
-"G3 [X] [Y] [IA] [JA] [F]"
+"G3 [X] [Y] [I] [J] [F]"
 
 
 +---------------------------------------------------
@@ -127,7 +127,7 @@ begin FIRST_CCW_ARC_MOVE
 
 begin CCW_ARC_MOVE
 
-"G3 [X] [Y] [IA] [JA]"
+"G3 [X] [Y] [I] [J]"
 
 
 +---------------------------------------------------


### PR DESCRIPTION
My tools (might be there are different results for other versions)
Aspire version 9.514
Snapmaker 2.0 A350

The created G2/G3 commands with absolute centers (IA/JA)were not working for me at all, creating full circles outside of the model:
![gcode error](https://user-images.githubusercontent.com/809528/87243758-d476f580-c438-11ea-8e44-63dc4052c8b1.png)

Changing this to use incremental centers (I/J) created correct gcode for me:
![gcode fixed](https://user-images.githubusercontent.com/809528/87243808-3172ab80-c439-11ea-9b6a-513b9e82e1c8.png)


